### PR TITLE
Add support contract data to info module

### DIFF
--- a/collections/ansible_collections/purestorage/pure1/README.md
+++ b/collections/ansible_collections/purestorage/pure1/README.md
@@ -10,6 +10,8 @@ The Pure Storage Pure1 collection consists of the latest versions of the Pure1 m
 - Authorized API Application ID for Pure Storage Pure1 and associated Private Key
   Refer to Pure Storage documentation on how to create these. 
 - py-pure-client >= 1.14.1
+- time
+- datetime
 
 ## Available Modules
 

--- a/collections/ansible_collections/purestorage/pure1/changelogs/fragments/8_add_perf_data.yaml
+++ b/collections/ansible_collections/purestorage/pure1/changelogs/fragments/8_add_perf_data.yaml
@@ -1,2 +1,2 @@
 minor_changes:
- - pure1_info - Add array performance data and load (FA only).
+ - pure1_info - Add array performance data and load (FA only). Add support contract status.

--- a/collections/ansible_collections/purestorage/pure1/requirements.txt
+++ b/collections/ansible_collections/purestorage/pure1/requirements.txt
@@ -1,1 +1,3 @@
 py-pure-client >= '1.14.1'
+time
+datetime

--- a/collections/ansible_collections/purestorage/pure1/requirements.txt
+++ b/collections/ansible_collections/purestorage/pure1/requirements.txt
@@ -1,3 +1,3 @@
-py-pure-client >= '1.14.1'
+py-pure-client >= '1.22.0'
 time
 datetime


### PR DESCRIPTION
##### SUMMARY
Add new subset of `contracts` to info module to provide contract status for appliances, including (where available) contract start and end dates

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
pure1_info.py