### PR TITLE
Update CI checks based on Ansible Core Team requirements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,32 +13,29 @@ jobs:
     strategy:
       matrix:
         ansible:
-          - stable-2.11
           - stable-2.12
           - stable-2.13
           - stable-2.14
           - stable-2.15
+          - stable-2.16
           - devel
         python-version:
-          - 3.8
-          - 3.9
           - "3.10"
           - "3.11"
+          - "3.12"
         exclude:
           - python-version: "3.11"
-            ansible: stable-2.11
-          - python-version: "3.11"
+            ansible: stable-2.12
+          - python-version: "3.12"
             ansible: stable-2.12
           - python-version: "3.11"
             ansible: stable-2.13
-          - python-version: "3.10"
-            ansible: stable-2.11
-          - python-version: 3.8
+          - python-version: "3.12"
+            ansible: stable-2.13
+          - python-version: "3.12"
             ansible: stable-2.14
-          - python-version: 3.8
+          - python-version: "3.12"
             ansible: stable-2.15
-          - python-version: 3.8
-            ansible: devel
     steps:
     - name: Check out code
       uses: actions/checkout@v3


### PR DESCRIPTION
Ansible Core Team require the following:

* Remove stable-2.11 tests
* Drop support for Python 3.9
* Add Python 3.12 for `devel`
* Oldest ansible-core version used for dev/test. Use Python version
    2.16 / devel      3.10 - 3.12
    2.14 and 2.15   3.10 - 3.11
    2.12 and 2.13   3.10
