### PR TITLE
Add py312 to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
           - 3.9
           - "3.10"
           - "3.11"
+          - "3.12"
         exclude:
           - python-version: 3.9
             ansible: stable-2.16
@@ -30,6 +31,8 @@ jobs:
             ansible: devel
           - python-version: "3.10"
             ansible: devel
+          - python-version: "3.12"
+            ansible: stable-2.15
     steps:
     - name: Check out code
       uses: actions/checkout@v3


### PR DESCRIPTION
##### SUMMARY
Add python 3.12 to CI tests (exclude 2.15 from py312 tests)